### PR TITLE
Use Working API Url

### DIFF
--- a/lib/nyc_api.rb
+++ b/lib/nyc_api.rb
@@ -1,10 +1,10 @@
 require 'net/http'
 require 'open-uri'
 require 'json'
- 
+
 class GetPrograms
 
-  URL = "http://data.cityofnewyork.us/resource/uvks-tn5n.json"
+  URL = "https://bronx.lehman.cuny.edu/resource/x9zi-ukip.json"
 
   def get_programs
     uri = URI.parse(URL)

--- a/nyc_api.rb
+++ b/nyc_api.rb
@@ -1,10 +1,10 @@
 require 'net/http'
- require 'open-uri'
- require 'json'
- 
- class GetPrograms
+require 'open-uri'
+require 'json'
 
-  URL = "http://data.cityofnewyork.us/resource/uvks-tn5n.json"
+class GetPrograms
+
+  URL = "https://bronx.lehman.cuny.edu/resource/x9zi-ukip.json"
 
   def get_programs
     uri = URI.parse(URL)
@@ -21,5 +21,5 @@ require 'net/http'
 
 end
 
- programs = GetPrograms.new.get_programs
- puts programs
+programs = GetPrograms.new
+puts programs.program_school


### PR DESCRIPTION
This pull request updates the `nyc_api.rb` file to change the data source URL. The original one that was used has since been made private, so you cannot access it. 

### Changes to the data source:

* Updated the `URL` constant in the `GetPrograms` class to point to a new API endpoint (`https://bronx.lehman.cuny.edu/resource/x9zi-ukip.json`) instead of the previous one (`http://data.cityofnewyork.us/resource/uvks-tn5n.json`). This ensures the application fetches data from the working source.